### PR TITLE
navbar consistent

### DIFF
--- a/src/Components/Navbar/Navbar.css
+++ b/src/Components/Navbar/Navbar.css
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: row;
   justify-content: end;
-  width: 50%;
+  width: 75%;
 }
 
 a {


### PR DESCRIPTION
In smaller mobile view the navbar text is all on one line.

<img width="871" height="138" alt="image" src="https://github.com/user-attachments/assets/ee7e2894-f798-43fa-acfa-57269020dbf7" />
